### PR TITLE
feat(prettier): pin prettier-2 to v2 until jest v30 release

### DIFF
--- a/npm-app.json
+++ b/npm-app.json
@@ -10,6 +10,11 @@
       "matchDatasources": ["npm"],
       "matchDepTypes": ["engines", "peerDependencies"],
       "rangeStrategy": "auto"
+    },
+    {
+      "description": "[Remove this after Jest v30 release]Jest v29 or lower do not support prettier v3. This rule ensures that the workaround of adding a prettier-2 package to devDependencies will be pinned to version 2. see https://github.com/jestjs/jest/issues/14305 for detail",
+      "matchPackageNames": ["prettier-2"],
+      "rangeStrategy": "pin"
     }
   ]
 }

--- a/npm-lib.json
+++ b/npm-lib.json
@@ -5,6 +5,11 @@
       "matchDatasources": ["npm"],
       "matchDepTypes": ["engines", "peerDependencies"],
       "semanticCommitType": "fix"
+    },
+    {
+      "description": "[Remove this after Jest v30 release]Jest v29 or lower do not support prettier v3. This rule ensures that the workaround of adding a prettier-2 package to devDependencies will be pinned to version 2. see https://github.com/jestjs/jest/issues/14305 for detail",
+      "matchPackageNames": ["prettier-2"],
+      "rangeStrategy": "pin"
     }
   ]
 }


### PR DESCRIPTION
Currently, Jest doesn't support Prettier v3. Therefore, we are adding a rule for projects that use Jest and are forced to include a prettier-2 dependency as a fix to pin the major version of prettier-2 to 2. This rule can be removed once Jest v30 is released, as Jest v30 will add support for Prettier v3, as indicated in the v30 alpha [release](https://github.com/jestjs/jest/releases/tag/v30.0.0-alpha.1).

For more details, please refer to: https://github.com/jestjs/jest/issues/14305#issuecomment-1668738936