### PR TITLE
fix(npm): only pin NPM related deps

### DIFF
--- a/npm-app.json
+++ b/npm-app.json
@@ -1,3 +1,15 @@
 {
-  "extends": [":npm", ":pinAllExceptPeerDependencies"]
+  "extends": [":npm"],
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "matchPackagePatterns": ["*"],
+      "rangeStrategy": "pin"
+    },
+    {
+      "matchDatasources": ["npm"],
+      "matchDepTypes": ["engines", "peerDependencies"],
+      "rangeStrategy": "auto"
+    }
+  ]
 }

--- a/npm-lib.json
+++ b/npm-lib.json
@@ -2,6 +2,7 @@
   "extends": [":npm", ":pinOnlyDevDependencies"],
   "packageRules": [
     {
+      "matchDatasources": ["npm"],
       "matchDepTypes": ["engines", "peerDependencies"],
       "semanticCommitType": "fix"
     }


### PR DESCRIPTION

**Description**

The preset is targeting all dependencies and not just NPM, which has some side effects as renovatebot trying to pin other languages versions / deps

**Changes**

* fix(npm): only pin NPM related deps

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
