### PR TITLE
feat(default): extend github-actions manager to look for subfolders

### DIFF
--- a/default.json
+++ b/default.json
@@ -32,5 +32,8 @@
       "matchUpdateTypes": ["minor", "patch"]
     }
   ],
-  "reviewersFromCodeOwners": true
+  "reviewersFromCodeOwners": true,
+  "github-actions": {
+    "fileMatch": ["(^|/).github/workflows/.+/.+\\.ya?ml$"]
+  }
 }


### PR DESCRIPTION
## background
We would like to have renovatebot's github-action package look into subfolders of `./github/workflows/<folder>/*.yaml`. The default regex file match for this package does not do so and only looks at `./github/workflows/*.yaml`

## changes
- Update `github-action` package to look at a single subdirectory