### PR TITLE
Enable Automerge on All CI Non-Major Dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,7 +18,8 @@
       "groupName": "all ci non-major dependencies",
       "groupSlug": "all-ci-minor-patch",
       "matchManagers": ["github-actions", "pre-commit", "docker-compose"],
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
     },
     {
       "groupName": "all non-major language versions",


### PR DESCRIPTION
## background

Most PRs for CI non-major dependencies are usually merged without any additional work if it passes CI. 

## changes
- Enable automerge on CI non-major dependencies
