### PR TITLE
Add `additional_dependencies` semantic version management support (for NodeJS packages only)

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,6 +13,16 @@
   "pre-commit": {
     "enabled": true
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^.pre-commit-config.yaml$"],
+      "matchStrings": [
+        "additional_dependencies:\\s*[-\\s]*['\"]?(?<depName>@?[^'\"\\s]+@(?<currentValue>[^'\"\\s]+))['\"]?",
+        "additional_dependencies:\\s*\\[\\s*['\"]?(?<depName>@?[^'\"\\s]+@(?<currentValue>[^'\"\\s]+))['\"]?\\s*\\]"
+      ]
+    }
+  ],
   "vulnerabilityAlerts": {
     "labels": ["security", "dependencies"],
     "prPriority": 1,

--- a/default.json
+++ b/default.json
@@ -16,6 +16,7 @@
   "customManagers": [
     {
       "customType": "regex",
+      "datasourceTemplate": "npm",
       "fileMatch": ["^.pre-commit-config.yaml$"],
       "matchStrings": [
         "additional_dependencies:\\s*[-\\s]*['\"]?(?<depName>@?[^'\"\\s]+@(?<currentValue>[^'\"\\s]+))['\"]?",


### PR DESCRIPTION
We have `additional_dependencies` using NodeJS pacakges in multiple projects. We should use renovate bot to manage semantic versioning automatically.

This PR aims to add support for that by utilizing Customer Managers https://docs.renovatebot.com/modules/manager/regex/

