### PR TITLE
feat: ignore @rive updates in npm-app config

### DIFF
--- a/npm-app.json
+++ b/npm-app.json
@@ -15,6 +15,12 @@
       "description": "[Remove this after Jest v30 release]Jest v29 or lower do not support prettier v3. This rule ensures that the workaround of adding a prettier-2 package to devDependencies will be pinned to version 2. see https://github.com/jestjs/jest/issues/14305 for detail",
       "matchPackageNames": ["prettier-2"],
       "rangeStrategy": "pin"
+    },
+    {
+      "description": "Ignore @rive-app updates: Rive code is defined in `npm-lib` repos. We should update versions there, bump peerDependencies, and then update apps accordingly. Opening @rive PRs in npm-app repos just generates useless CI cycles.",
+      "enabled": false,
+      "groupName": "@rive Dependencies",
+      "matchPackageNames": ["/@rive-app//"]
     }
   ]
 }


### PR DESCRIPTION
This PR was originally in a repo that added the `npm-app` config, but we should be extending it to all `npm-app` repos. Our `@rive` definitions are only in `npm-lib` repos: version updates should happen there, with `peerDependencies` bumps that are followed up by `npm-app` repo version updates. We don't want to update the app separately from where the core logic is defined. 