### PR TITLE
feat: ignore @emotion/jest@11.13.0

### DIFF
--- a/npm-app.json
+++ b/npm-app.json
@@ -21,6 +21,11 @@
       "enabled": false,
       "groupName": "@rive Dependencies",
       "matchPackageNames": ["/@rive-app//"]
+    },
+    {
+      "description": "@emotion/jest@11.13.0 creates a memory leak in our test suite: https://github.com/emotion-js/emotion/issues/3221",
+      "matchPackageNames": ["@emotion/jest"],
+      "allowedVersions": "!11.13.0"
     }
   ]
 }

--- a/npm-lib.json
+++ b/npm-lib.json
@@ -10,6 +10,11 @@
       "description": "[Remove this after Jest v30 release]Jest v29 or lower do not support prettier v3. This rule ensures that the workaround of adding a prettier-2 package to devDependencies will be pinned to version 2. see https://github.com/jestjs/jest/issues/14305 for detail",
       "matchPackageNames": ["prettier-2"],
       "rangeStrategy": "pin"
+    },
+    {
+      "description": "@emotion/jest@11.13.0 creates a memory leak in our test suite: https://github.com/emotion-js/emotion/issues/3221",
+      "matchPackageNames": ["@emotion/jest"],
+      "allowedVersions": "!11.13.0"
     }
   ]
 }


### PR DESCRIPTION
This version has a memory leak, so we do not want Renovate to update to this version when updating `@emotion` monorepo packages.