### PR TITLE
c/action-yaml-custom-managers

### DIFF
--- a/default.json
+++ b/default.json
@@ -44,14 +44,31 @@
   "github-actions": {
     "fileMatch": ["(^|/).github/workflows/.+/.+\\.ya?ml$"]
   },
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": ["(^|/)Dockerfile($|\\..+)"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?(?: extractVersion=(?<extractVersion>.+?))?\\s(?:ENV|ARG) .+?_VERSION=\"?(?<currentValue>[^\"\\s]+)\"?\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
       "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["action\\.ya?ml$", "(^|/)\\.github/.+\\.ya?ml$"],
+      "matchStrings": [
+        "node-version:\\s*[\"']?(?<currentValue>\\d+[\\d.]*)[\"']?",
+        "echo \"version=(?<currentValue>\\d+)\" >> \\$GITHUB_OUTPUT"
+      ],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["action\\.ya?ml$", "(^|/)\\.github/.+\\.ya?ml$"],
+      "matchStrings": ["\"(?<depName>@?[^@\"]+)@(?<currentValue>[^\"]+)\""],
+      "datasourceTemplate": "npm"
     }
   ]
 }


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
Add custom managers for node-version and npm detection in action/workflow YAML files
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
**Why:** Renovate doesn't natively detect node versions or npm package versions in GitHub Action YAML files and workflow files. This was validated in open-turo/action-pre-commit first.

**What changed:**
- Migrated deprecated `regexManagers` to `customManagers` with `customType: "regex"`
- Added node-version detection for hardcoded `node-version:` arguments and `echo "version=XX"` defaults
- Added npm package detection for `"@scope/pkg@version"` patterns in install commands
- File matching covers `action.ya?ml` and `.github/**/*.ya?ml`
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
<!-- fotingo:end fixed-issues -->

**Changes**

<!-- fotingo:start changes -->
* feat: add support for renovate comment in dockerfiles (+21/-1)
* feat: add custom managers for node-version and npm in action YAML files (+18/-1)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)