### PR TITLE
feat: add 3-day minimum release age to npm configs

### DIFF
--- a/default.json
+++ b/default.json
@@ -38,6 +38,10 @@
         "node-version"
       ],
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
     }
   ],
   "reviewersFromCodeOwners": true,

--- a/npm-app.json
+++ b/npm-app.json
@@ -26,6 +26,10 @@
       "description": "@emotion/jest@11.13.0 creates a memory leak in our test suite: https://github.com/emotion-js/emotion/issues/3221",
       "matchPackageNames": ["@emotion/jest"],
       "allowedVersions": "!/11.13.0/"
+    },
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
     }
   ]
 }

--- a/npm-lib.json
+++ b/npm-lib.json
@@ -15,6 +15,10 @@
       "description": "@emotion/jest@11.13.0 creates a memory leak in our test suite: https://github.com/emotion-js/emotion/issues/3221",
       "matchPackageNames": ["@emotion/jest"],
       "allowedVersions": "!/11.13.0/"
+    },
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
     }
   ]
 }

--- a/npm.json
+++ b/npm.json
@@ -8,6 +8,10 @@
           "rangeStrategy": "update-lockfile"
         }
       ]
+    },
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest", "npmDedupe", "pnpmDedupe"]


### PR DESCRIPTION
## Summary

- Adds `minimumReleaseAge: "3 days"` to `npm.json`, `npm-app.json`, and `npm-lib.json`, scoped to `matchDatasources: ["npm"]`
- Aligns with Renovate's `config:best-practices` preset which already sets a 3-day minimum for the npm ecosystem
- Ensures all Turo repos inheriting these configs wait 72 hours before adopting any new npm package version, giving security scanners a window to surface supply chain compromises
- Motivated by the [TanStack shai-hulud supply chain attack](https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack)
- Non-npm ecosystems (Docker, JVM, Terraform) are intentionally unchanged

## Test plan

- [ ] Verify `npm.json`, `npm-app.json`, `npm-lib.json` each contain the new `minimumReleaseAge` rule
- [ ] Confirm `docker.json`, `jvm.json`, `terraform.json` are unchanged
- [ ] Validate JSON linting passes (pre-commit hook covers this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)