### PR TITLE
feat: add severity labels (patch/minor/major) to all dependency PRs

### DIFF
--- a/default.json
+++ b/default.json
@@ -42,6 +42,21 @@
     {
       "matchDatasources": ["npm"],
       "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Add specific labels for major dependency updates",
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["dependency-major"]
+    },
+    {
+      "description": "Add specific labels for minor dependency updates",
+      "matchUpdateTypes": ["minor"],
+      "addLabels": ["dependency-minor"]
+    },
+    {
+      "description": "Add specific labels for patch dependency updates",
+      "matchUpdateTypes": ["patch"],
+      "addLabels": ["dependency-patch"]
     }
   ],
   "reviewersFromCodeOwners": true,


### PR DESCRIPTION
## Summary
- Add `addLabels` rules in `default.json` to automatically label all Renovate PRs with `dependency-patch`, `dependency-minor`, or `dependency-major` based on update type
- This applies to **all repos** extending `open-turo/renovate-config`, regardless of their local `packageRules` (Renovate concatenates `packageRules` from presets and local config)

## Rollout plan

1. Merge this PR (semantic-release auto-tags a new version)
2. Renovate auto-creates bump PRs on all consumer repos — merge them as they come in
3. Validate on a floating-tag repo (node-traffic-utils) that labels appear correctly
4. Close the 12 individual PRs once all repos are confirmed bumped (keep as fallback until then)

🤖 Generated with [Claude Code](https://claude.com/claude-code)