### PR TITLE
fix: add minimumReleaseAge exceptions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - name: Validate
         run: npx --yes --package renovate -- renovate-config-validator
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Pre-commit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Pre-commit
@@ -22,6 +22,14 @@ jobs:
       - name: Check release notes on pull_request
         if: github.event_name == 'pull_request'
         uses: open-turo/actions-release/lint-release-notes@v5
+  validate:
+    name: Validate Renovate config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Validate
+        run: npx --yes --package renovate -- renovate-config-validator
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Pre-commit
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
       - name: Setup tools
         uses: open-turo/action-setup-tools@v3
       - name: Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Pre-commit
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup tools
         uses: open-turo/action-setup-tools@v3
       - name: Release

--- a/default.json
+++ b/default.json
@@ -49,7 +49,7 @@
       "minimumReleaseAge": null
     },
     {
-      "description": "Reduce age gate to 2 days for eslint packages",
+      "description": "Reduce age gate to 2 days for specific packages",
       "matchPackageNames": ["/^eslint/", "/^@eslint//"],
       "minimumReleaseAge": "2 days"
     },

--- a/default.json
+++ b/default.json
@@ -44,13 +44,8 @@
       "minimumReleaseAge": "3 days"
     },
     {
-      "description": "Bypass age gate for internally maintained @turo packages",
-      "matchPackageNames": ["/^@turo//"],
-      "minimumReleaseAge": null
-    },
-    {
-      "description": "Bypass age gate for specific trusted packages — add package names here for 0-day exceptions",
-      "matchPackageNames": ["/^@types//"],
+      "description": "No minimum release age for internal and trusted packages",
+      "matchPackageNames": ["/^@turo//", "/^@types//"],
       "minimumReleaseAge": null
     },
     {

--- a/default.json
+++ b/default.json
@@ -46,7 +46,7 @@
     },
     {
       "description": "Remove minimum release age for internal @turo namespaced packages, and other trusted and/or safe exceptions.",
-      "matchPackageNames": ["/^@turo//", "/^@types//"],
+      "matchPackageNames": ["/^@turo//", "/^@open-turo//", "/^@types//"],
       "minimumReleaseAge": null
     },
     {

--- a/default.json
+++ b/default.json
@@ -45,8 +45,23 @@
     },
     {
       "description": "Bypass age gate for internally maintained @turo packages",
-      "matchPackagePatterns": ["^@turo/"],
+      "matchPackageNames": ["/^@turo//"],
       "minimumReleaseAge": null
+    },
+    {
+      "description": "Bypass age gate for specific trusted packages — add package names here for 0-day exceptions",
+      "matchPackageNames": [],
+      "minimumReleaseAge": null
+    },
+    {
+      "description": "Reduce age gate to 2 days for eslint packages",
+      "matchPackageNames": ["/^eslint/", "/^@eslint//"],
+      "minimumReleaseAge": "2 days"
+    },
+    {
+      "description": "Reduce age gate to 1 day for @types packages",
+      "matchPackageNames": ["/^@types//"],
+      "minimumReleaseAge": "1 day"
     },
     {
       "description": "Add specific labels for major dependency updates",

--- a/default.json
+++ b/default.json
@@ -40,23 +40,24 @@
       "matchUpdateTypes": ["minor", "patch"]
     },
     {
+      "description": "Apply a 3-day minimum release age to NPM dependencies by default, for security purposes.",
       "matchDatasources": ["npm"],
       "minimumReleaseAge": "3 days"
     },
     {
-      "description": "No minimum release age for internal and trusted packages",
+      "description": "Remove minimum release age for internal @turo namespaced packages, and other trusted and/or safe exceptions.",
       "matchPackageNames": ["/^@turo//", "/^@types//"],
       "minimumReleaseAge": null
     },
     {
-      "description": "Reduce age gate to 2 days for specific packages",
-      "matchPackageNames": ["/^eslint/", "/^@eslint//"],
-      "minimumReleaseAge": "2 days"
+      "description": "Reduce age gate to 3 days to 1 day day for specific packages, where we want to update much more frequently, and especially do not expect security risk.",
+      "matchPackageNames": ["react", "react-dom"],
+      "minimumReleaseAge": "1 day"
     },
     {
-      "description": "Reduce age gate to 1 day for specific packages — add package names here for 1-day exceptions",
-      "matchPackageNames": [],
-      "minimumReleaseAge": "1 day"
+      "description": "Reduce age gate from 3 days to 2 days for specific packages, where we want to update somewhat more frequently, and do not expect security risk.",
+      "matchPackageNames": ["/^eslint/", "/^@eslint//"],
+      "minimumReleaseAge": "2 days"
     },
     {
       "description": "Add specific labels for major dependency updates",

--- a/default.json
+++ b/default.json
@@ -50,7 +50,7 @@
     },
     {
       "description": "Bypass age gate for specific trusted packages — add package names here for 0-day exceptions",
-      "matchPackageNames": [],
+      "matchPackageNames": ["/^@types//"],
       "minimumReleaseAge": null
     },
     {
@@ -59,8 +59,8 @@
       "minimumReleaseAge": "2 days"
     },
     {
-      "description": "Reduce age gate to 1 day for @types packages",
-      "matchPackageNames": ["/^@types//"],
+      "description": "Reduce age gate to 1 day for specific packages — add package names here for 1-day exceptions",
+      "matchPackageNames": [],
       "minimumReleaseAge": "1 day"
     },
     {

--- a/default.json
+++ b/default.json
@@ -60,7 +60,9 @@
         "/^eslint/",
         "/^@eslint//",
         "/^prettier/",
-        "/^@prettier//"
+        "/^@prettier//",
+        "/^@typescript-eslint//",
+        "typescript-eslint"
       ],
       "minimumReleaseAge": "2 days"
     },

--- a/default.json
+++ b/default.json
@@ -56,7 +56,12 @@
     },
     {
       "description": "Reduce age gate from 3 days to 2 days for specific packages, where we want to update somewhat more frequently, and do not expect security risk.",
-      "matchPackageNames": ["/^eslint/", "/^@eslint//"],
+      "matchPackageNames": [
+        "/^eslint/",
+        "/^@eslint//",
+        "/^prettier/",
+        "/^@prettier//"
+      ],
       "minimumReleaseAge": "2 days"
     },
     {

--- a/default.json
+++ b/default.json
@@ -44,6 +44,11 @@
       "minimumReleaseAge": "3 days"
     },
     {
+      "description": "Bypass age gate for internally maintained @turo packages",
+      "matchPackagePatterns": ["^@turo/"],
+      "minimumReleaseAge": null
+    },
+    {
       "description": "Add specific labels for major dependency updates",
       "matchUpdateTypes": ["major"],
       "addLabels": ["dependency-major"]

--- a/npm.json
+++ b/npm.json
@@ -14,13 +14,8 @@
       "minimumReleaseAge": "3 days"
     },
     {
-      "description": "Bypass age gate for internally maintained @turo packages",
-      "matchPackageNames": ["/^@turo//"],
-      "minimumReleaseAge": null
-    },
-    {
-      "description": "Bypass age gate for specific trusted packages — add package names here for 0-day exceptions",
-      "matchPackageNames": ["/^@types//"],
+      "description": "No minimum release age for internal and trusted packages",
+      "matchPackageNames": ["/^@turo//", "/^@types//"],
       "minimumReleaseAge": null
     },
     {

--- a/npm.json
+++ b/npm.json
@@ -15,8 +15,23 @@
     },
     {
       "description": "Bypass age gate for internally maintained @turo packages",
-      "matchPackagePatterns": ["^@turo/"],
+      "matchPackageNames": ["/^@turo//"],
       "minimumReleaseAge": null
+    },
+    {
+      "description": "Bypass age gate for specific trusted packages — add package names here for 0-day exceptions",
+      "matchPackageNames": [],
+      "minimumReleaseAge": null
+    },
+    {
+      "description": "Reduce age gate to 2 days for eslint packages",
+      "matchPackageNames": ["/^eslint/", "/^@eslint//"],
+      "minimumReleaseAge": "2 days"
+    },
+    {
+      "description": "Reduce age gate to 1 day for @types packages",
+      "matchPackageNames": ["/^@types//"],
+      "minimumReleaseAge": "1 day"
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest", "npmDedupe", "pnpmDedupe"]

--- a/npm.json
+++ b/npm.json
@@ -16,7 +16,7 @@
     },
     {
       "description": "Remove minimum release age for internal @turo namespaced packages, and other trusted and/or safe exceptions.",
-      "matchPackageNames": ["/^@turo//", "/^@types//"],
+      "matchPackageNames": ["/^@turo//", "/^@open-turo//", "/^@types//"],
       "minimumReleaseAge": null
     },
     {

--- a/npm.json
+++ b/npm.json
@@ -10,23 +10,24 @@
       ]
     },
     {
+      "description": "Apply a 3-day minimum release age to NPM dependencies by default, for security purposes.",
       "matchDatasources": ["npm"],
       "minimumReleaseAge": "3 days"
     },
     {
-      "description": "No minimum release age for internal and trusted packages",
+      "description": "Remove minimum release age for internal @turo namespaced packages, and other trusted and/or safe exceptions.",
       "matchPackageNames": ["/^@turo//", "/^@types//"],
       "minimumReleaseAge": null
     },
     {
-      "description": "Reduce age gate to 2 days for specific packages",
-      "matchPackageNames": ["/^eslint/", "/^@eslint//"],
-      "minimumReleaseAge": "2 days"
+      "description": "Reduce age gate to 3 days to 1 day day for specific packages, where we want to update much more frequently, and especially do not expect security risk.",
+      "matchPackageNames": ["react", "react-dom"],
+      "minimumReleaseAge": "1 day"
     },
     {
-      "description": "Reduce age gate to 1 day for specific packages — add package names here for 1-day exceptions",
-      "matchPackageNames": [],
-      "minimumReleaseAge": "1 day"
+      "description": "Reduce age gate from 3 days to 2 days for specific packages, where we want to update somewhat more frequently, and do not expect security risk.",
+      "matchPackageNames": ["/^eslint/", "/^@eslint//"],
+      "minimumReleaseAge": "2 days"
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest", "npmDedupe", "pnpmDedupe"]

--- a/npm.json
+++ b/npm.json
@@ -30,7 +30,9 @@
         "/^eslint/",
         "/^@eslint//",
         "/^prettier/",
-        "/^@prettier//"
+        "/^@prettier//",
+        "/^@typescript-eslint//",
+        "typescript-eslint"
       ],
       "minimumReleaseAge": "2 days"
     }

--- a/npm.json
+++ b/npm.json
@@ -19,7 +19,7 @@
       "minimumReleaseAge": null
     },
     {
-      "description": "Reduce age gate to 2 days for eslint packages",
+      "description": "Reduce age gate to 2 days for specific packages",
       "matchPackageNames": ["/^eslint/", "/^@eslint//"],
       "minimumReleaseAge": "2 days"
     },

--- a/npm.json
+++ b/npm.json
@@ -20,7 +20,7 @@
     },
     {
       "description": "Bypass age gate for specific trusted packages — add package names here for 0-day exceptions",
-      "matchPackageNames": [],
+      "matchPackageNames": ["/^@types//"],
       "minimumReleaseAge": null
     },
     {
@@ -29,8 +29,8 @@
       "minimumReleaseAge": "2 days"
     },
     {
-      "description": "Reduce age gate to 1 day for @types packages",
-      "matchPackageNames": ["/^@types//"],
+      "description": "Reduce age gate to 1 day for specific packages — add package names here for 1-day exceptions",
+      "matchPackageNames": [],
       "minimumReleaseAge": "1 day"
     }
   ],

--- a/npm.json
+++ b/npm.json
@@ -12,6 +12,11 @@
     {
       "matchDatasources": ["npm"],
       "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Bypass age gate for internally maintained @turo packages",
+      "matchPackagePatterns": ["^@turo/"],
+      "minimumReleaseAge": null
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest", "npmDedupe", "pnpmDedupe"]

--- a/npm.json
+++ b/npm.json
@@ -26,7 +26,12 @@
     },
     {
       "description": "Reduce age gate from 3 days to 2 days for specific packages, where we want to update somewhat more frequently, and do not expect security risk.",
-      "matchPackageNames": ["/^eslint/", "/^@eslint//"],
+      "matchPackageNames": [
+        "/^eslint/",
+        "/^@eslint//",
+        "/^prettier/",
+        "/^@prettier//"
+      ],
       "minimumReleaseAge": "2 days"
     }
   ],


### PR DESCRIPTION
## Summary

- Adds a `minimumReleaseAge: null` (0-day) exception for `@open-turo/*`, `@turo/*` and `@types/*` packages
- Adds a 1-day exception rule for `react`, `react-dom`. 
- Adds a 2-day exception rule for `eslint*`, `@eslint/*`, `prettier*`, `@prettier/*`, `@typescript-eslint/*`, and `typescript-eslint`
- All exceptions are in both `default.json` and `npm.json` to remain consistent with how the base 3-day rule is applied
- Adds a `renovate-config-validator` CI check (`npx --yes --package renovate -- renovate-config-validator`)
- Migrates `matchPackagePatterns` (deprecated) to regex entries in `matchPackageNames`

## Test plan

- [ ] Confirm Renovate config validates cleanly (`renovate-config-validator`)
- [ ] Verify `@turo/*` and `@types/*` dependency updates open PRs without delay
- [ ] Verify `eslint*`, `@eslint/*`, `prettier*`, `@prettier/*`, `@typescript-eslint/*`, and `typescript-eslint` updates respect a 2-day hold
- [ ] Verify non-excepted npm dependencies still respect the 3-day minimum

🤖 Generated with [Claude Code](https://claude.com/claude-code)